### PR TITLE
Fix: Cannot convert undefined or null to object at assign (<anonymous>)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@react-navigation/native": "^5.5.1",
     "@react-navigation/stack": "^5.5.1",
     "@testing-library/jest-native": "^3.1.0",
-    "@testing-library/react-native": "^5.0.3",
+    "@testing-library/react-native": "^6.0.0",
     "axios": "^0.19.2",
     "intl": "^1.2.5",
     "react": "16.13.1",


### PR DESCRIPTION
Broken tests with React Native 0.63.3

See: https://github.com/testing-library/native-testing-library/issues/126